### PR TITLE
 A more robust approach to handling unique nodes. 

### DIFF
--- a/JamKit.gd
+++ b/JamKit.gd
@@ -1,14 +1,23 @@
 extends Node
 
+var _unique_nodes: Dictionary = {} setget set_unique_nodes, get_unique_nodes
+
+func set_unique_node(id: String, node: Node, allow_replacing := false):
+	if not allow_replacing and id in _unique_nodes:
+		printerr("Unique node " + id + 
+			" already exists. If you wish to allow this, try 'set_unique_node(" + 
+			id + ", " + node.name + ", true)'")
+		breakpoint
+	
+	_unique_nodes[id] = Node
 
 func get_unique_node(id: String) -> Node:
-	var group := get_tree().get_nodes_in_group(id)
-	if len( group ) == 0:
-		return null
-	
-	if len( group ) != 1:
-		printerr("WARNING: Unique node `" + id + "` is being used by multiple nodes:")
-		for node in group:
-			printerr("  " + node.name)
-	
-	return group[0]
+	return _unique_nodes[id]
+
+# Setget functions for _unique_nodes. Warn users when they try to access or manipulate it. 
+func set_unique_nodes(new_unique_nodes: Dictionary):
+	printerr("JamKit: direct access to '_unique_nodes' is not recommended. Try using 'set_unique_node()' or 'replace_unique_node()' instead.")
+	_unique_nodes = new_unique_nodes
+func get_unique_nodes():
+	printerr("JamKit: direct access to '_unique_nodes' is not recommended. Try using 'get_unique_node()' instead.")
+	return _unique_nodes

--- a/JamKit.gd
+++ b/JamKit.gd
@@ -1,23 +1,26 @@
 extends Node
 
-var _unique_nodes: Dictionary = {} setget set_unique_nodes, get_unique_nodes
+var __unique_nodes: Dictionary = {} setget __set__unique_nodes, __get__unique_nodes
 
-func set_unique_node(id: String, node: Node, allow_replacing := false):
-	if not allow_replacing and id in _unique_nodes:
-		printerr("Unique node " + id + 
-			" already exists. If you wish to allow this, try 'set_unique_node(" + 
-			id + ", " + node.name + ", true)'")
-		breakpoint
+func set_unique_node(id: String, node: Node, replace := false):
+	assert( not (replace == false and id in __unique_nodes) ) # set `replace` parameter to replace unique node
+	if replace == false and id in __unique_nodes:
+		return
 	
-	_unique_nodes[id] = Node
+	__unique_nodes[id] = node
 
 func get_unique_node(id: String) -> Node:
-	return _unique_nodes[id]
+	if not id in __unique_nodes:
+		return null
+	if id in __unique_nodes and __unique_nodes[id] == null:
+		__unique_nodes.erase(id)
+		return null
+	return __unique_nodes[id]
 
-# Setget functions for _unique_nodes. Warn users when they try to access or manipulate it. 
-func set_unique_nodes(new_unique_nodes: Dictionary):
-	printerr("JamKit: direct access to '_unique_nodes' is not recommended. Try using 'set_unique_node()' or 'replace_unique_node()' instead.")
-	_unique_nodes = new_unique_nodes
-func get_unique_nodes():
-	printerr("JamKit: direct access to '_unique_nodes' is not recommended. Try using 'get_unique_node()' instead.")
-	return _unique_nodes
+# Setget functions for __unique_nodes. Warn users when they try to access or manipulate it. 
+func __set__unique_nodes(new__unique_nodes: Dictionary):
+	printerr("JamKit: direct access to '__unique_nodes' is not recommended. Try using 'set_unique_node()' or 'replace_unique_node()' instead.")
+	__unique_nodes = new__unique_nodes
+func __get__unique_nodes():
+	printerr("JamKit: direct access to '__unique_nodes' is not recommended. Try using 'get_unique_node()' instead.")
+	return __unique_nodes

--- a/tests/TestUniqueNode.tscn
+++ b/tests/TestUniqueNode.tscn
@@ -6,30 +6,55 @@ script/source = "extends Node2D
 
 
 func _ready() -> void:
-	# unique node doesn't exist
+	var failed_tests = 0
+	var test_count = 4
+	
+	print(\"--TEST: unique node has not been set.--\")
 	var no_unique_node := JamKit.get_unique_node(\"Unique\")
-	print(no_unique_node)
-	assert(no_unique_node == null)
+	if no_unique_node == null:
+		print(\"Passed.\")
+	else:
+		print(\"Failed.\")
+		failed_tests += 1
 	
-	$UniqueNode.add_to_group(\"Unique\")
+	JamKit.set_unique_node(\"Unique\", $UniqueNode)
 	
-	# unique node does exist
-	var true_unique_node = JamKit.get_unique_node(\"Unique\")
-	print(true_unique_node)
-	assert(true_unique_node is Node)
+	print(\"--TEST: unique node has been set.--\")
+	var first_unique_node := JamKit.get_unique_node(\"Unique\")
+	if first_unique_node is Node:
+		print(\"Passed.\")
+	else:
+		print(\"Failed.\")
+		failed_tests += 1
 	
-	add_child( $UniqueNode.duplicate() )
+	print(\"--TEST: can't replace unique node without setting `replace` parameter.--\")
+	JamKit.set_unique_node(\"Unique\", $UniqueNode2)
+	var second_unique_node := JamKit.get_unique_node(\"Unique\")
+	if first_unique_node == second_unique_node:
+		print(\"Passed.\")
+	else:
+		print(\"Failed.\")
+		failed_tests += 1
 	
-	# unique node is not unique
-	var not_unique_node := JamKit.get_unique_node(\"Unique\")
-	print( \"Non-unique gets same result as unique.\" if not_unique_node == true_unique_node else \"Non-unique gets different result from unique\")
-	assert(not_unique_node == true_unique_node)
+	print(\"--TEST: can replace unique node when `replace` parameter is true.--\")
+	JamKit.set_unique_node(\"Unique\", $UniqueNode2, true)
+	var third_unique_node := JamKit.get_unique_node(\"Unique\")
+	if first_unique_node != third_unique_node:
+		print(\"Passed.\")
+	else:
+		print(\"Failed.\")
+		failed_tests += 1
 	
-	print(\"TESTS PASSED\")
+	if failed_tests == 0:
+		print(\"TESTS PASSED\")
+	else:
+		print(\"FAILED \" + str(failed_tests) + \" OF \" + str(test_count) + \" TESTS\")
 	get_tree().quit()"
 
 [node name="TestUniqueNode" type="Node2D"]
 script = SubResource( 1 )
 
 [node name="UniqueNode" type="Node2D" parent="."]
+
+[node name="UniqueNode2" type="Node2D" parent="."]
 


### PR DESCRIPTION
Store unique nodes in a dictionary instead of reusing node 
groups. Prevents duplicates, and access can be controlled. 
For example: replacing a unique node must now be explicitly 
requested.